### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Guidance for installing the nidirect-frontend node package manager (npm) package
 - For more information on npm, read the node.js article, [What is npm?](https://nodejs.org/en/knowledge/getting-started/npm/what-is-npm/)
 ##  Before you install the nidirect-frontend package
- - You need to install [node.js](https://nodejs.org/en/) and the [govuk-frontend npm package](https://www.npmjs.com/package/govuk-frontend).  For guidance on how to do this, visit the [GOV.UK frontend website](https://frontend.design-system.service.gov.uk/installing-with-npm/#requirements).
+ - You need to install [node.js](https://nodejs.org/en/) and the [govuk-frontend npm package version 3.14.0](https://www.npmjs.com/package/govuk-frontend/v/3.14.0).  For guidance on how to do this, visit the [GOV.UK frontend website](https://frontend.design-system.service.gov.uk/installing-with-npm/#requirements).
  - You will need a Sass compiler to generate the CSS code for both packages.
 ## Installing the nidirect-frontend package
 - Open a command line window;


### PR DESCRIPTION
The GOV.UK front end V4.0.0 has been released, we need to test our current nidirect front end with it for any compatibility issues. In the meantime I have updated the Read Me file to ensure the users are directed to the last known compatible version 3.14.0