### PR TITLE
Update to nidirect-frontend to work with govuk-frontend version 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Guidance for installing the nidirect-frontend node package manager (npm) package
 - For more information on npm, read the node.js article, [What is npm?](https://nodejs.org/en/knowledge/getting-started/npm/what-is-npm/)
-##  Before you install the nidirect-frontend package
- - You need to install [node.js](https://nodejs.org/en/) and the [govuk-frontend npm package version 3.14.0](https://www.npmjs.com/package/govuk-frontend/v/3.14.0).  For guidance on how to do this, visit the [GOV.UK frontend website](https://frontend.design-system.service.gov.uk/installing-with-npm/#requirements).
- - You will need a Sass compiler to generate the CSS code for both packages.
-## Installing the nidirect-frontend package
-- Open a command line window;
-- Navigate to the root folder of your application.  Using the change directory command `cd` followed by the path to the root folder. 
 
-For example: 
-  `cd user/documents/myapplication` 
-  
-- Within your application's root folder, install the npm package using the command:
+##  Before you install the nidirect-frontend package
+You will need to:
+- Install [node.js](https://nodejs.org/en/)
+- Install [govuk-frontend npm package version 5.0.0](https://www.npmjs.com/package/govuk-frontend/v/5.0.0) or above. For guidance on how to do this, visit the [GOV.UK frontend website](https://frontend.design-system.service.gov.uk/installing-with-npm/#requirements).
+- Install a SASS compiler to generate the CSS code for both packages. Most popular integrated development environments (IDE) support plugins or extensions that allow you to compile SASS easily. Or if you prefer, you can compile the SASS manually using the command line.
+
+## Installing the nidirect-frontend package
+1. Open a command line window
+2. Use the change directory command `cd` followed by the path to the root folder of your application.   
+...For example: `cd user/documents/myapplication`  
+3. Within your application's root folder, install the npm package using the command:
 
   `npm i nidirect-frontend`
   
- When the installation finishes, the nidirect-frontend package will be in the same folder that govuk-frontend package is held.
+4. When the installation finishes, the nidirect-frontend package will be in the same folder that govuk-frontend package is held.
   
 ## Implementing the code in your project
- - Once you have verified that both the govuk-frontend and nidirect-frontend packages are in your project folder, compile the Sass.  
-     -Most popular integrated development environments (IDE) support plugins or exentions that allow you to compile SASS easily.
- - If you prefer, you can compile the Sass manually using the command line.
+1. Check that both the govuk-frontend and nidirect-frontend packages are in your project folder
+2. Use a SASS compiler with the file `nidirect-all.scss` to generate the CSS code for both packages.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You will need to:
 
 ## Installing the nidirect-frontend package
 1. Open a command line window
-2. Use the change directory command `cd` followed by the path to the root folder of your application.   
+2. Navigate to root folder of your application using the change directory command `cd` followed by the path to the root folder of your application.   
 
    For example: `cd user/documents/myapplication`  
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You will need to:
 
 3. Within your application's root folder, install the npm package using the command:
 
-  `npm i nidirect-frontend`
+   `npm i nidirect-frontend`
   
 4. When the installation finishes, the nidirect-frontend package will be in the same folder that govuk-frontend package is held.
   

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 ##  Before you install the nidirect-frontend package
 You will need to:
 - Install [node.js](https://nodejs.org/en/)
-- Install [govuk-frontend npm package version 5.0.0](https://www.npmjs.com/package/govuk-frontend/v/5.0.0) or above. For guidance on how to do this, visit the [GOV.UK frontend website](https://frontend.design-system.service.gov.uk/installing-with-npm/#requirements).
-- Install a SASS compiler to generate the CSS code for both packages. Most popular integrated development environments (IDE) support plugins or extensions that allow you to compile SASS easily. Or if you prefer, you can compile the SASS manually using the command line.
+- Install [govuk-frontend npm package version 5.0.0](https://www.npmjs.com/package/govuk-frontend/v/5.0.0) or above.
+  For guidance on how to do this, visit the [GOV.UK frontend website](https://frontend.design-system.service.gov.uk/installing-with-npm/#requirements).
+- Install a SASS compiler to generate the CSS code for both packages.
+  Most popular integrated development environments (IDE) support plugins or extensions that allow you to compile SASS easily. Or if you prefer, you can compile the SASS manually using the command line.
 
 ## Installing the nidirect-frontend package
 1. Open a command line window
 2. Use the change directory command `cd` followed by the path to the root folder of your application.   
-...For example: `cd user/documents/myapplication`  
+
+  For example: `cd user/documents/myapplication`  
+
 3. Within your application's root folder, install the npm package using the command:
 
   `npm i nidirect-frontend`

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 ##  Before you install the nidirect-frontend package
 You will need to:
 - Install [node.js](https://nodejs.org/en/)
-- Install [govuk-frontend npm package version 5.0.0](https://www.npmjs.com/package/govuk-frontend/v/5.0.0) or above.
+- Install [govuk-frontend npm package version 5.0.0](https://www.npmjs.com/package/govuk-frontend/v/5.0.0) or above.  
   For guidance on how to do this, visit the [GOV.UK frontend website](https://frontend.design-system.service.gov.uk/installing-with-npm/#requirements).
-- Install a SASS compiler to generate the CSS code for both packages.
+- Install a SASS compiler to generate the CSS code for both packages.  
   Most popular integrated development environments (IDE) support plugins or extensions that allow you to compile SASS easily. Or if you prefer, you can compile the SASS manually using the command line.
 
 ## Installing the nidirect-frontend package
 1. Open a command line window
 2. Use the change directory command `cd` followed by the path to the root folder of your application.   
 
-  For example: `cd user/documents/myapplication`  
+   For example: `cd user/documents/myapplication`  
 
 3. Within your application's root folder, install the npm package using the command:
 


### PR DESCRIPTION
Since govuk-frontend updated to version 5.0.0 the following changes needed to be made to the nidirect-frontend to make it compatible with govuk-frontend version 5.0.0 and WCAG 2.2.

## Header changes
- Redesigned the structure of the header to work with govuk header styles and to clean up code
- No font attributed to header so added font to nidirect-header class
- `Aria-hidden` attribute on menu button changed to `hidden` attribute as it fails accessibility checks via axe and wave.
- Restructured nav to use the same structure used in govuk-frontend header component
- Changed all absolute values (pixels) to rems so design will scale correctly when zoomed on browser or mobile screens.
- Changed the nav item to act and look like links to overcome the focus state overflowing the nav bar. Focus state is now just around text
- Added vertical spacing breakpoints for the menu button to ensure it is vertically centred on mobile and tablet breakpoints
- Added a stroke below the nav items container so users using high contrast will be able to see the visual separation between nav items and service name
- On mobile screens - changed the active nav item style to a vertical stroke on LHS as the bottom horizontal stroke was hard to see beside the horizontal lines separating the nav items
- On mobile screens - reduced the spacing between nav items to conserve space and meet the WCAG 2.2. target size mimimum of 24px
- Changed vertical spacing of blue and gray bars so that they will appear the same height on all breakpoints.

## Footer changes
- Redesigned the structure of the footer as it used two empty paragraph tags to space rather than using css padding attribute.
- Needed to increase vertical spacing between links to meet the WCAG 2.2. -target size minimum of 24 px
- On mobile breakpoint made into a vertical list to make easier to read when screen magnified to 400%. Taken from GOVUK footer design
- Changed background colour to match background colour of footer present in govuk template page
- Added hidden h2 heading - ‘support links’ into footer to help screen reader users and users who turn off css know what the links in the footer are for. Taken from GOVUK footer design
- 